### PR TITLE
feature: splash page made

### DIFF
--- a/app/src/main/java/com/example/devmart/AppNav.kt
+++ b/app/src/main/java/com/example/devmart/AppNav.kt
@@ -1,14 +1,10 @@
 package com.example.devmart
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.*
 import com.example.devmart.ui.auth.LoginScreen
+import com.example.devmart.ui.auth.SplashScreen
 import com.example.devmart.ui.home.HomeScreen
 import com.example.devmart.ui.home.ProductDetailScreen
 import com.example.devmart.ui.session.AuthState
@@ -20,25 +16,26 @@ fun AppNav() {
     val session: SessionViewModel = hiltViewModel()
     val auth by session.auth.collectAsState()
 
-    LaunchedEffect(auth) {
-        when (auth) {
-            is AuthState.Authenticated ->
-                nav.navigate(Route.MainGraph.path) { popUpTo(0) { inclusive = true } }
-            AuthState.Unauthenticated ->
-                nav.navigate(Route.AuthGraph.path) { popUpTo(0) { inclusive = true } }
-            AuthState.Loading -> Unit
-        }
-    }
-
-    if (auth is AuthState.Loading) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
-        return
-    }
-
     NavHost(
         navController = nav,
-        startDestination = if (auth is AuthState.Authenticated) Route.MainGraph.path else Route.AuthGraph.path
+        startDestination = Route.Splash.path
     ) {
+        // 스플래시 화면
+        composable(Route.Splash.path) {
+            SplashScreen(
+                onTimeout = {
+                    // 2초 후 인증 상태에 따라 이동
+                    when (auth) {
+                        is AuthState.Authenticated ->
+                            nav.navigate(Route.MainGraph.path) { popUpTo(0) { inclusive = true } }
+                        else ->
+                            nav.navigate(Route.AuthGraph.path) { popUpTo(0) { inclusive = true } }
+                    }
+                }
+            )
+        }
+
+        // 인증 그래프
         navigation(startDestination = Route.Login.path, route = Route.AuthGraph.path) {
             composable(Route.Login.path) { LoginScreen() }
         }

--- a/app/src/main/java/com/example/devmart/AppRoutes.kt
+++ b/app/src/main/java/com/example/devmart/AppRoutes.kt
@@ -1,6 +1,7 @@
 package com.example.devmart
 
 sealed class Route(val path: String) {
+    data object Splash : Route("splash")
     data object AuthGraph : Route("auth")
     data object MainGraph : Route("main")
     data object Login : Route("login")

--- a/app/src/main/java/com/example/devmart/ui/auth/Splash.kt
+++ b/app/src/main/java/com/example/devmart/ui/auth/Splash.kt
@@ -1,0 +1,66 @@
+package com.example.devmart.ui.auth
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
+import com.example.devmart.ui.theme.DevDarkneyvy
+import com.example.devmart.ui.theme.DevFonts
+import com.example.devmart.ui.theme.DevMartTheme
+import com.example.devmart.ui.theme.DevViolte
+import kotlinx.coroutines.delay
+
+@Composable
+fun SplashScreen(
+    onTimeout: () -> Unit = {}
+) {
+    // 2초 후 다음 화면으로 이동
+    LaunchedEffect(Unit) {
+        delay(2000L)
+        onTimeout()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(DevViolte),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // 위쪽 2/5 공간
+        Spacer(modifier = Modifier.weight(2f))
+        
+        // 앱 이름 (전체의 3/5 위치 = 위에서 2/5 지점)
+        Text(
+            text = "Dev Mart",
+            fontSize = 44.sp,
+            fontFamily = DevFonts.KakaoBigSans,
+            fontWeight = FontWeight.ExtraBold,
+            color = DevDarkneyvy,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        
+        // 아래쪽 3/5 공간
+        Spacer(modifier = Modifier.weight(3f))
+    }
+}
+
+// ------------------ Preview ------------------
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun PreviewSplashScreen() {
+    DevMartTheme {
+        SplashScreen()
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new splash screen and route, making it the start destination and navigating after 2s based on auth state.
> 
> - **Navigation**:
>   - Set `NavHost` start to `Route.Splash` in `AppNav.kt`.
>   - Add `Route.Splash` in `AppRoutes.kt`.
>   - Replace previous auth-driven `LaunchedEffect` redirect with splash-driven navigation to `Route.MainGraph` or `Route.AuthGraph`.
> - **UI**:
>   - Add `ui/auth/Splash.kt` with `SplashScreen` that delays 2s then calls `onTimeout` to route.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60fed0ced7e4d3f768960c46baea25d0c50eb823. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->